### PR TITLE
Fix evm address lookup / Always show checksumed EVM address 

### DIFF
--- a/frontend/components/Transfer.vue
+++ b/frontend/components/Transfer.vue
@@ -72,13 +72,17 @@
             </div>
             <div v-if="JSON.parse(transfer.args)[0].address20">
               <eth-identicon
-                :address="JSON.parse(transfer.args)[0].address20"
+                :address="
+                  toChecksumAddress(JSON.parse(transfer.args)[0].address20)
+                "
                 :size="20"
               />
               <nuxt-link
-                :to="`/account/${JSON.parse(transfer.args)[0].address20}`"
+                :to="`/account/${toChecksumAddress(
+                  JSON.parse(transfer.args)[0].address20
+                )}`"
               >
-                {{ JSON.parse(transfer.args)[0].address20 }}
+                {{ toChecksumAddress(JSON.parse(transfer.args)[0].address20) }}
               </nuxt-link>
             </div>
           </td>
@@ -137,6 +141,7 @@
 <script>
 import { Promised } from 'vue-promised'
 import commonMixin from '@/mixins/commonMixin.js'
+import { toChecksumAddress } from 'web3-utils'
 export default {
   components: { Promised },
   mixins: [commonMixin],
@@ -144,6 +149,11 @@ export default {
     transfer: {
       type: Object,
       default: () => undefined,
+    },
+  },
+  methods: {
+    toChecksumAddress(address) {
+      return toChecksumAddress(address)
     },
   },
 }

--- a/frontend/middleware/account.js
+++ b/frontend/middleware/account.js
@@ -1,11 +1,12 @@
 import gql from 'graphql-tag'
+import { toChecksumAddress } from 'web3-utils'
 export default async function ({ app, route, store, redirect }) {
   const id = route.params.id
   if (id.match(/0x*/)) {
     const client = app.apolloProvider.defaultClient
     const query = gql`
       query account {
-        account(where: {evm_address: {_eq: "${id}"}}) {
+        account(where: {evm_address: {_eq: "${toChecksumAddress(id)}"}}) {
           account_id
         }
       }


### PR DESCRIPTION
- Allow to use non checksumed EVM addresses for account lookup
- Show/ Link to checksumed EVM address in Transfer page