### PR TITLE
Refactor docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,16 @@
+NODE_BUILD_CONTEXT=https://github.com/reef-defi/reef-chain.git#v8
+NODE_IMAGE=reef_node:v8
+NODE_HOST=substrate-node
+NODE_PORT=30333
+NODE_WS=9944
+NODE_MAX_CONS=1000
+DB_NAME=reefexplorer
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=reefexplorer
+DB_PW=reefexplorer
+DB_URL=postgres://reefexplorer:reefexplorer@postgres:5432/reefexplorer
+GQL_CONSOLE=true
+GQL_UNAUTHORIZED_ROLE=public
+GQL_ADMIN_PW=myadminsecretkey
+API_PORT=8000

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+ifeq ($(env), dev)
+	NODE_CHAIN_CMD=--dev
+	NODE_CHAIN=
+else
+	NODE_CHAIN_CMD=--chain
+	NODE_CHAIN=$(env)
+endif
+
+up:
+	NODE_CHAIN_CMD=$(NODE_CHAIN_CMD) NODE_CHAIN=$(NODE_CHAIN) docker-compose -p reef-explorer-$(env) up -d
+
+down:
+	docker-compose -p reef-explorer-$(env) down
+
+purge:
+	docker volume rm reef-explorer-$(env)_substrate-data && docker volume rm reef-explorer-$(env)_db-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,115 @@
+version: '3.7'
+
+services:
+  substrate-node:
+    build:
+      context: ${NODE_BUILD_CONTEXT}
+    image: ${NODE_IMAGE}
+    volumes:
+      - substrate-data:/data
+    ports:
+      - ${NODE_PORT}:${NODE_PORT}
+      - ${NODE_WS}:${NODE_WS}
+    # TODO paramaterise chain
+    command: -d /data --ws-max-connections ${NODE_MAX_CONS} ${NODE_CHAIN_CMD} ${NODE_CHAIN} --pruning=archive --rpc-cors "*" --ws-port ${NODE_WS} --port ${NODE_PORT} --unsafe-ws-external --no-prometheus --no-telemetry
+    restart: always
+    networks:
+      - reefscan
+
+  postgres:
+    image: postgres:13
+    restart: always
+    shm_size: 1gb
+    volumes:
+      - 'db-data:/var/lib/postgresql/data'
+      - './db/sql/initialization/init.sql:/docker-entrypoint-initdb.d/00_init.sql'
+      - './db/sql/initialization/block.sql:/docker-entrypoint-initdb.d/01_block.sql'
+      - './db/sql/initialization/account.sql:/docker-entrypoint-initdb.d/02_account.sql'
+      - './db/sql/initialization/extrinsic.sql:/docker-entrypoint-initdb.d/03_extrinsic.sql'
+      - './db/sql/initialization/event.sql:/docker-entrypoint-initdb.d/04_event.sql'
+      - './db/sql/initialization/contract.sql:/docker-entrypoint-initdb.d/05_contract.sql'
+      - './db/sql/initialization/evmEvent.sql:/docker-entrypoint-initdb.d/06_evmEvent.sql'
+      - './db/sql/initialization/transfer.sql:/docker-entrypoint-initdb.d/07_transfer.sql'
+      - './db/sql/initialization/staking.sql:/docker-entrypoint-initdb.d/08_staking.sql'
+      - './db/sql/initialization/chainInfo.sql:/docker-entrypoint-initdb.d/09_chainInfo.sql'
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: ${DB_USER} #'reefexplorer'
+      POSTGRES_PASSWORD: ${DB_PW} #'reefexplorer'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U reefexplorer']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - reefscan
+
+  graphql-engine:
+    image: hasura/graphql-engine:v2.1.1.cli-migrations-v3
+    ports:
+      - 8080:8080
+    volumes:
+      - './db/hasura/metadata:/hasura-metadata'
+    depends_on:
+      - 'postgres'
+    restart: always
+    environment:
+      HASURA_GRAPHQL_DATABASE_URL: ${DB_URL} #postgres://reefexplorer:reefexplorer@postgres:5432/reefexplorer
+      HASURA_GRAPHQL_ENABLE_CONSOLE: ${GQL_CONSOLE} #'true' # set to "false" to disable console
+      HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
+      HASURA_GRAPHQL_UNAUTHORIZED_ROLE: ${GQL_UNAUTHORIZED_ROLE} #public
+      HASURA_GRAPHQL_ADMIN_SECRET: ${GQL_ADMIN_PW} #myadminsecretkey
+    networks:
+      - reefscan
+
+  crawler:
+    image: crawler
+    build: 
+      context: ./crawler
+    restart: always
+    environment:
+      - NODE_PROVIDER_URLS=["ws://substrate-node:9944"] #TODO extract this list
+      - START_BLOCK_STEP=32
+      # with 8 nodes you can process up to 4096 blocks at once but rather keep it at 1024 if server doesn't have a lot of RAM.
+      # Currently we support node with 16Gb of RAM. To change the capacity go in `./crawler/package.json` and change --max-old-space-size=16384 to desired size
+      - MAX_BLOCKS_PER_STEP=1024
+      - POSTGRES_PORT=${DB_PORT} #5432
+      - POSTGRES_HOST=${DB_HOST}
+      - POSTGRES_USER=${DB_USER} #reefexplorer
+      - POSTGRES_DATABASE=${DB_NAME} #reefexplorer
+      - POSTGRES_PASSWORD=${DB_PW} #reefexplorer
+    depends_on:
+      - 'postgres'
+      - 'substrate-node'
+    networks:
+      - reefscan
+
+  api:
+    image: api
+    build:
+      context: ./api
+    restart: always
+    environment:
+      - PORT=${API_PORT} #8000
+      - NODE_URL=ws://${NODE_HOST}:${NODE_WS}
+      - POSTGRES_PORT=${DB_PORT}
+      - POSTGRES_HOST=${DB_HOST}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_DATABASE=${DB_NAME}
+      - POSTGRES_PASSWORD=${DB_PW}
+      - RECAPTCHA_SECRET=6LfNcPIaAAAAADSldnLXXxSrXIYH532l0cSsfDEU
+    depends_on:
+      - postgres
+      - substrate-node
+    networks:
+      - reefscan
+
+# Persistent volumes
+volumes:
+  db-data: {}
+  substrate-data: {}
+
+networks:
+  reefscan:
+    name: reefscan


### PR DESCRIPTION
This PR refactors docker-compose.  A new paramaterised docker-compose file is provided with companion .env.   A Makefile is currently used for execution using the following commands:

```
make env=dev up
make env=dev down
make env=dev purge
```

env can take the following values:
env=dev, env=testnet, env=mainnet