### PR TITLE
refactor registry error metadata retrieval pattern

### DIFF
--- a/crawler/src/crawler/extrinsic.ts
+++ b/crawler/src/crawler/extrinsic.ts
@@ -8,8 +8,9 @@ export const resolveSigner = (extrinsic: Extrinsic): string => extrinsic.signer?
 
 const extractErrorMessage = (error: SpRuntimeDispatchError): string => {
   if (error.isModule) {
-    const decoded = getProvider().api.registry.findMetaError(error.asModule);
-    return `${decoded.section}.${decoded.name}`;
+    const errorModule = error.asModule;
+    const { docs, name, section } = errorModule.registry.findMetaError(errorModule);
+    return `${section}.${name}: ${docs}`;
   } else {
     return error.toString();
   }


### PR DESCRIPTION
This PR refactors the way in which we fetch metadata associated with reef-chain errors.  Previously we were requesting error metadata directly from the provider which was causing issues with errors which are no longer present in the most recent metadata.  This PR modifies the metadata access pattern such that we leverage the error module to access the registry and required error metadata. 