### PR TITLE
Pages repared, Contract Sources view adjusted

### DIFF
--- a/db/hasura/metadata/databases/reefexplorer/tables/public_chain_info.yaml
+++ b/db/hasura/metadata/databases/reefexplorer/tables/public_chain_info.yaml
@@ -1,0 +1,10 @@
+table:
+  name: chain_info
+  schema: public
+select_permissions:
+- permission:
+    columns:
+    - name
+    - count
+    filter: {}
+  role: public

--- a/db/hasura/metadata/databases/reefexplorer/tables/public_contract.yaml
+++ b/db/hasura/metadata/databases/reefexplorer/tables/public_contract.yaml
@@ -15,6 +15,14 @@ object_relationships:
       table:
         name: verified_contract
         schema: public
+array_relationships:
+- name: token_holders
+  using:
+    foreign_key_constraint_on:
+      column: token_address
+      table:
+        schema: public
+        name: token_holder
 select_permissions:
 - permission:
     allow_aggregations: true

--- a/db/hasura/metadata/databases/reefexplorer/tables/public_transfer.yaml
+++ b/db/hasura/metadata/databases/reefexplorer/tables/public_transfer.yaml
@@ -8,6 +8,9 @@ object_relationships:
 - name: to_account
   using:
     foreign_key_constraint_on: to_address
+- name: token
+  using:
+    foreign_key_constraint_on: token_address
 - name: block
   using:
     foreign_key_constraint_on: block_id

--- a/db/hasura/metadata/databases/reefexplorer/tables/tables.yaml
+++ b/db/hasura/metadata/databases/reefexplorer/tables/tables.yaml
@@ -10,3 +10,4 @@
 - "!include public_verified_contract.yaml"
 - "!include public_verified_evm_call.yaml"
 - "!include public_staking.yaml"
+- "!include public_chain_info.yaml"

--- a/frontend/mixins/commonMixin.js
+++ b/frontend/mixins/commonMixin.js
@@ -2,7 +2,6 @@ import { hexToU8a, isHex } from '@polkadot/util'
 import { BigNumber } from 'bignumber.js'
 import { gql } from 'graphql-tag'
 import { decodeAddress, encodeAddress } from '@polkadot/keyring'
-import { checkAddressChecksum } from 'web3-utils'
 import moment from 'moment'
 import { network } from '@/frontend.config.js'
 import { reefChainErrors } from '@/reef-chain-errors.js'
@@ -142,9 +141,6 @@ export default {
     isContractId: (contractId) => {
       if (!contractId) return false
       if (contractId.length !== 42) return false
-      if (!checkAddressChecksum(contractId)) {
-        return false
-      }
       return true
     },
     //

--- a/frontend/pages/accounts.vue
+++ b/frontend/pages/accounts.vue
@@ -270,6 +270,7 @@ export default {
   apollo: {
     $subscribe: {
       accounts: {
+        // TODO add limit and offset!
         query: gql`
           query account {
             account(order_by: { free_balance: desc }, where: {}) {

--- a/frontend/pages/blocks.vue
+++ b/frontend/pages/blocks.vue
@@ -133,21 +133,20 @@ export default {
           this.loading = false
         },
       },
-      /* totalBlocks: {
-        // TODO when chain_info is in gql
+      totalBlocks: {
         query: gql`
-          subscription total {
-            total(where: { name: { _eq: "blocks" } }, limit: 1) {
+          subscription chain_info {
+            chain_info(where: { name: { _eq: "blocks" } }, limit: 1) {
               count
             }
           }
         `,
         result({ data }) {
           if (!this.filter) {
-            this.totalRows = data.total[0].count
+            this.totalRows = data.chain_info[0].count
           }
         },
-      }, */
+      },
     },
   },
 }

--- a/frontend/pages/blocks.vue
+++ b/frontend/pages/blocks.vue
@@ -134,21 +134,20 @@ export default {
           this.loading = false
         },
       },
-      /* totalBlocks: {
-        // TODO when chain_info is in gql
+      totalBlocks: {
         query: gql`
-          subscription total {
-            total(where: { name: { _eq: "blocks" } }, limit: 1) {
+          subscription chain_info {
+            chain_info(where: { name: { _eq: "blocks" } }, limit: 1) {
               count
             }
           }
         `,
         result({ data }) {
           if (!this.filter) {
-            this.totalRows = data.total[0].count
+            this.totalRows = data.chain_info[0].count
           }
         },
-      }, */
+      },
     },
   },
 }

--- a/frontend/pages/contracts.vue
+++ b/frontend/pages/contracts.vue
@@ -160,32 +160,34 @@ export default {
             perPage: this.perPage,
             offset: (this.currentPage - 1) * this.perPage,
           }
-          console.log('nnnn=', newVar)
           return newVar
         },
         result({ data }) {
           this.contracts = data.contract
+          // TODO filter does not work
           if (this.filter) {
             this.totalRows = this.contracts.length
           }
           this.loading = false
         },
       },
-      /* TODO
       totalContracts: {
         query: gql`
           subscription total {
-            total(where: { name: { _eq: "contracts" } }, limit: 1) {
-              count
+            contract_aggregate {
+              aggregate {
+                count
+              }
             }
           }
         `,
         result({ data }) {
           if (!this.filter) {
-            this.totalRows = data.total[0].count
+            console.log(data)
+            this.totalRows = data.contract_aggregate.aggregate.count
           }
         },
-      }, */
+      },
     },
   },
 }

--- a/frontend/pages/contracts.vue
+++ b/frontend/pages/contracts.vue
@@ -118,6 +118,7 @@ export default {
       perPage: null,
       currentPage: 1,
       totalRows: 1,
+      nContracts: 0,
     }
   },
   apollo: {
@@ -164,10 +165,7 @@ export default {
         },
         result({ data }) {
           this.contracts = data.contract
-          // TODO filter does not work
-          if (this.filter) {
-            this.totalRows = this.contracts.length
-          }
+          this.totalRows = this.filter ? this.contracts.length : this.nContracts
           this.loading = false
         },
       },
@@ -182,10 +180,8 @@ export default {
           }
         `,
         result({ data }) {
-          if (!this.filter) {
-            console.log(data)
-            this.totalRows = data.contract_aggregate.aggregate.count
-          }
+          this.nContracts = data.contract_aggregate.aggregate.count
+          this.totalRows = this.nContracts
         },
       },
     },

--- a/frontend/pages/events.vue
+++ b/frontend/pages/events.vue
@@ -80,6 +80,7 @@ export default {
       perPage: null,
       currentPage: 1,
       totalRows: 1,
+      nEvents: 0,
     }
   },
   apollo: {
@@ -116,9 +117,7 @@ export default {
         },
         result({ data }) {
           this.events = data.event
-          if (this.filter) {
-            this.totalRows = this.events.length
-          }
+          this.totalRows = this.filter ? this.events.length : this.nEvents
           this.loading = false
         },
       },
@@ -131,9 +130,8 @@ export default {
           }
         `,
         result({ data }) {
-          if (!this.filter) {
-            this.totalRows = data.chain_info[0].count
-          }
+          this.nEvents = data.chain_info[0].count
+          this.totalRows = this.nEvents
         },
       },
     },

--- a/frontend/pages/events.vue
+++ b/frontend/pages/events.vue
@@ -122,21 +122,20 @@ export default {
           this.loading = false
         },
       },
-      /* TODO
-          totalEvents: {
+      totalEvents: {
         query: gql`
-          subscription total {
-            total(where: { name: { _eq: "events" } }, limit: 1) {
+          subscription chain_info {
+            chain_info(where: { name: { _eq: "events" } }, limit: 1) {
               count
             }
           }
         `,
         result({ data }) {
           if (!this.filter) {
-            this.totalRows = data.total[0].count
+            this.totalRows = data.chain_info[0].count
           }
         },
-      }, */
+      },
     },
   },
 }

--- a/frontend/pages/extrinsics.vue
+++ b/frontend/pages/extrinsics.vue
@@ -95,6 +95,7 @@ export default {
       perPage: null,
       currentPage: 1,
       totalRows: 1,
+      nExtrinsics: 0,
     }
   },
   apollo: {
@@ -132,24 +133,23 @@ export default {
         },
         result({ data }) {
           this.extrinsics = data.extrinsic
-          if (this.filter) {
-            this.totalRows = this.extrinsics.length
-          }
+          this.totalRows = this.filter
+            ? this.extrinsics.length
+            : this.nExtrinsics
           this.loading = false
         },
       },
       totalExtrinsics: {
         query: gql`
-          subscription chain_info {
+          subscription total {
             chain_info(where: { name: { _eq: "extrinsics" } }, limit: 1) {
               count
             }
           }
         `,
         result({ data }) {
-          if (!this.filter) {
-            this.totalRows = data.chain_info[0].count
-          }
+          this.nExtrinsics = data.chain_info[0].count
+          this.totalRows = this.nExtrinsics
         },
       },
     },

--- a/frontend/pages/extrinsics.vue
+++ b/frontend/pages/extrinsics.vue
@@ -138,20 +138,20 @@ export default {
           this.loading = false
         },
       },
-      // totalExtrinsics: {
-      //   query: gql`
-      //     subscription total {
-      //       total(where: { name: { _eq: "extrinsics" } }, limit: 1) {
-      //         count
-      //       }
-      //     }
-      //   `,
-      //   result({ data }) {
-      //     if (!this.filter) {
-      //       this.totalRows = data.total[0].count
-      //     }
-      //   },
-      // },
+      totalExtrinsics: {
+        query: gql`
+          subscription chain_info {
+            chain_info(where: { name: { _eq: "extrinsics" } }, limit: 1) {
+              count
+            }
+          }
+        `,
+        result({ data }) {
+          if (!this.filter) {
+            this.totalRows = data.chain_info[0].count
+          }
+        },
+      },
     },
   },
 }

--- a/frontend/pages/token/_id.vue
+++ b/frontend/pages/token/_id.vue
@@ -201,9 +201,9 @@
 
           <!-- Source -->
 
-          <pre v-if="tab === 'source'" class="token-details__source">{{
-            contract.verified_contract.source
-          }}</pre>
+          <pre v-if="tab === 'source'" class="token-details__source">
+            <vue-json-pretty :data="contract.source" />
+          </pre>
 
           <!-- Transactions -->
 
@@ -333,6 +333,16 @@ export default {
               data.contract[0].verified_contract.compiled_data[name]
                 ? data.contract[0].verified_contract.compiled_data[name]
                 : []
+
+            this.contract.source = Object.keys(
+              data.contract[0].verified_contract.source
+            ).reduce(
+              (acc, current) => [
+                ...acc,
+                `\n${current}\n---------------------------\n${data.contract[0].verified_contract.source[current]}`,
+              ],
+              []
+            )
           }
           this.loading = false
         },

--- a/frontend/pages/tokens.vue
+++ b/frontend/pages/tokens.vue
@@ -19,21 +19,21 @@
               <Cell>Name</Cell>
               <Cell>Contract Address</Cell>
               <!--              TODO Ziga
-              <Cell align="right">Total supply</Cell>
-              <Cell align="right">Holders</Cell>-->
+              <Cell align="right">Total supply</Cell>-->
+              <Cell align="right">Holders</Cell>
             </THead>
 
             <Row v-for="(item, index) in tokens" :key="index">
               <Cell
-                v-if="item.verified_contract && item.verified_contract.name"
+                v-if="item.contract_data && item.contract_data.name"
                 :link="`/token/${item.address}`"
               >
                 <img
-                  v-if="item.verified_contract.token_icon_url"
-                  :src="item.verified_contract.token_icon_url"
+                  v-if="item.contract_data.token_icon_url"
+                  :src="item.contract_data.token_icon_url"
                   class="identicon"
                 />
-                <span>{{ item.verified_contract.name }}</span>
+                <span>{{ item.contract_data.name }}</span>
                 <font-awesome-icon
                   v-if="item.verified_contract"
                   v-b-tooltip.hover
@@ -51,11 +51,11 @@
               </Cell>
 
               <!-- TODO Ziga
-              <Cell align="right">{{ getItemSupply(item) }}</Cell>
+              <Cell align="right">{{ getItemSupply(item) }}</Cell>-->
 
               <Cell align="right">
-                {{ item.holders_aggregate.aggregate.count }}
-              </Cell>-->
+                {{ item.contract.token_holders_aggregate.aggregate.count }}
+              </Cell>
             </Row>
           </Table>
 
@@ -100,13 +100,6 @@ export default {
   apollo: {
     $subscribe: {
       tokens: {
-        /* TODO Ziga - missing holders_aggregate in query
-
-        holders_aggregate {
-          aggregate {
-            count(columns: holder_account_id)
-          }
-        } */
         query: gql`
           subscription contract(
             $blockHeight: extrinsic_bool_exp
@@ -114,50 +107,49 @@ export default {
             $perPage: Int!
             $offset: Int!
           ) {
-            contract(
+            verified_contract(
               limit: $perPage
               offset: $offset
-              where: {
-                extrinsic: $blockHeight
-                address: $contractAddress
-                verified_contract: { type: { _eq: "ERC20" } }
-              }
-              order_by: { extrinsic: { block_id: desc } }
+              where: { type: { _eq: "ERC20" } }
+              order_by: { contract: { extrinsic: { block_id: desc } } }
             ) {
               address
-              verified_contract {
-                address
-                name
-                args
-                source
-                compiler_version
-                compiled_data
-                optimization
-                runs
-                target
-                type
+              contract_data
+              contract {
+                timestamp
+                token_holders_aggregate {
+                  aggregate {
+                    count(distinct: true)
+                  }
+                }
+                extrinsic {
+                  hash
+                }
+                signer
               }
-              timestamp
             }
           }
         `,
         variables() {
-          const bHeight = this.isBlockNumber(this.filter)
-            ? parseInt(this.filter)
-            : undefined
-          const cAddress = this.isContractId(this.filter)
-            ? this.filter
-            : undefined
+          // TODO add filter
+          // const bHeight = this.isBlockNumber(this.filter)
+          //   ? parseInt(this.filter)
+          //   : undefined
+          // const cAddress = this.isContractId(this.filter)
+          //   ? this.filter
+          //   : undefined
           return {
-            blockHeight: bHeight ? { block_id: { _eq: bHeight } } : {},
-            contractAddress: cAddress ? { _eq: cAddress } : {},
+            // blockHeight: bHeight
+            //   ? { contract: { extrinsic: { block_id: { _eq: bHeight } } } }
+            //   : {},
+            // contractAddress: cAddress ? { _eq: cAddress } : {},
             perPage: this.perPage,
             offset: (this.currentPage - 1) * this.perPage,
           }
         },
         result({ data }) {
-          if (data && data.contract) {
-            this.tokens = data.contract
+          if (data && data.verified_contract) {
+            this.tokens = data.verified_contract
             if (this.filter) {
               this.totalRows = this.tokens.length
             }
@@ -165,11 +157,10 @@ export default {
           this.loading = false
         },
       },
-      /* TODO Ziga
       totaltokens: {
         query: gql`
           query contract_aggregate {
-            contract_aggregate(where: { is_erc20: { _eq: true } }) {
+            verified_contract_aggregate(where: { type: { _eq: "ERC20" } }) {
               aggregate {
                 count
               }
@@ -178,10 +169,10 @@ export default {
         `,
         result({ data }) {
           if (!this.filter) {
-            this.totalRows = data.contract_aggregate.aggregate.count
+            this.totalRows = data.verified_contract_aggregate.aggregate.count
           }
         },
-      }, */
+      },
     },
   },
   methods: {

--- a/frontend/pages/transfers.vue
+++ b/frontend/pages/transfers.vue
@@ -119,6 +119,7 @@ export default {
       perPage: null,
       currentPage: 1,
       totalRows: 1,
+      nTransfers: 0,
     }
   },
   apollo: {
@@ -135,6 +136,10 @@ export default {
             transfer(
               limit: $perPage
               offset: $offset
+              where: {
+                extrinsic: { block_id: $blockNumber, hash: $extrinsicHash }
+                from_account: { address: $fromAddress }
+              }
               order_by: { block_id: desc, extrinsic: { index: desc } }
             ) {
               extrinsic {
@@ -155,14 +160,13 @@ export default {
         `,
         variables() {
           return {
-            // TODO enable filtering
-            // blockNumber: this.isBlockNumber(this.filter)
-            //   ? { _eq: parseInt(this.filter) }
-            //   : {},
-            // extrinsicHash: this.isHash(this.filter) ? { _eq: this.filter } : {},
-            // fromAddress: this.isAddress(this.filter)
-            //   ? { _eq: this.filter }
-            //   : {},
+            blockNumber: this.isBlockNumber(this.filter)
+              ? { _eq: parseInt(this.filter) }
+              : {},
+            extrinsicHash: this.isHash(this.filter) ? { _eq: this.filter } : {},
+            fromAddress: this.isAddress(this.filter)
+              ? { _eq: this.filter }
+              : {},
             perPage: this.perPage,
             offset: (this.currentPage - 1) * this.perPage,
           }
@@ -186,9 +190,7 @@ export default {
               block_id: extrinsic.block_id,
             })
           )
-          if (this.filter) {
-            this.totalRows = this.transfers.length
-          }
+          this.totalRows = this.filter ? this.transfers.length : this.nTransfers
           this.loading = false
         },
       },
@@ -203,10 +205,8 @@ export default {
           }
         `,
         result({ data }) {
-          if (!this.filter) {
-            console.log(data)
-            this.totalRows = data.transfer_aggregate.aggregate.count
-          }
+          this.nTransfers = data.transfer_aggregate.aggregate.count
+          this.totalRows = this.nTransfers
         },
       },
     },

--- a/frontend/pages/transfers.vue
+++ b/frontend/pages/transfers.vue
@@ -132,119 +132,83 @@ export default {
             $perPage: Int!
             $offset: Int!
           ) {
-            extrinsic(
+            transfer(
               limit: $perPage
               offset: $offset
-              order_by: { block_id: desc, index: desc }
-              where: {
-                _or: [
-                  {
-                    section: { _eq: "currencies" }
-                    method: { _like: "transfer" }
-                    block_id: $blockNumber
-                    hash: $extrinsicHash
-                    signer: $fromAddress
-                  }
-                  {
-                    section: { _eq: "balances" }
-                    method: { _like: "transfer%" }
-                    block_id: $blockNumber
-                    hash: $extrinsicHash
-                    signer: $fromAddress
-                  }
-                ]
-              }
+              order_by: { block_id: desc, extrinsic: { index: desc } }
             ) {
-              block_id
-              section
-              signer
-              hash
-              args
-              status
+              extrinsic {
+                hash
+                block_id
+              }
+              from_account {
+                address
+              }
+              to_account {
+                address
+              }
+              success
+              amount
               timestamp
             }
           }
         `,
         variables() {
           return {
-            blockNumber: this.isBlockNumber(this.filter)
-              ? { _eq: parseInt(this.filter) }
-              : {},
-            extrinsicHash: this.isHash(this.filter) ? { _eq: this.filter } : {},
-            fromAddress: this.isAddress(this.filter)
-              ? { _eq: this.filter }
-              : {},
+            // TODO enable filtering
+            // blockNumber: this.isBlockNumber(this.filter)
+            //   ? { _eq: parseInt(this.filter) }
+            //   : {},
+            // extrinsicHash: this.isHash(this.filter) ? { _eq: this.filter } : {},
+            // fromAddress: this.isAddress(this.filter)
+            //   ? { _eq: this.filter }
+            //   : {},
             perPage: this.perPage,
             offset: (this.currentPage - 1) * this.perPage,
           }
         },
         result({ data }) {
-          this.transfers = data.extrinsic.map((transfer) => {
-            return {
-              block_id: transfer.block_id,
-              hash: transfer.hash,
-              from: transfer.signer,
-              to: transfer.args[0].address20
-                ? transfer.args[0].address20
-                : transfer.args[0].id,
-              amount:
-                transfer.section === 'currencies'
-                  ? transfer.args[2]
-                  : transfer.args[1],
-              success: transfer.status === 'success',
-              timestamp: transfer.timestamp,
-            }
-          })
+          this.transfers = data.transfer.map(
+            ({
+              success,
+              timestamp,
+              from_account: from,
+              to_account: to,
+              amount,
+              extrinsic,
+            }) => ({
+              amount,
+              success,
+              timestamp,
+              to: to.address,
+              from: from.address,
+              hash: extrinsic.hash,
+              block_id: extrinsic.block_id,
+            })
+          )
+          if (this.filter) {
+            this.totalRows = this.transfers.length
+          }
           this.loading = false
         },
       },
-      /* count: {
+      totalTransfers: {
         query: gql`
-          subscription count(
-            $blockNumber: bigint
-            $extrinsicHash: String
-            $fromAddress: String
-            $toAddress: String
-          ) {
-            extrinsic(
-              where: {
-                _or: [
-                  {
-                    section: { _eq: "currencies" }
-                    method: { _like: "transfer" }
-                    block_id: { _eq: $blockNumber }
-                    hash: { _eq: $extrinsicHash }
-                    signer: { _eq: $fromAddress }
-                  }
-                  {
-                    section: { _eq: "balances" }
-                    method: { _like: "transfer%" }
-                    block_id: { _eq: $blockNumber }
-                    hash: { _eq: $extrinsicHash }
-                    signer: { _eq: $fromAddress }
-                  }
-                ]
-              }
-            ) {
+          subscription total {
+            transfer_aggregate {
               aggregate {
                 count
               }
             }
           }
         `,
-        variables() {
-          return {
-            blockNumber: this.isBlockNumber(this.filter)
-              ? parseInt(this.filter)
-              : undefined,
-            extrinsicHash: this.isHash(this.filter) ? this.filter : undefined,
-            fromAddress: this.isAddress(this.filter) ? this.filter : undefined,
+        result({ data }) {
+          if (!this.filter) {
+            console.log(data)
+            this.totalRows = data.transfer_aggregate.aggregate.count
           }
         },
-        result({ data }) {
-          this.totalRows = data.extrinsic_aggregate.aggregate.count
-        },
-      }, */
+      },
     },
   },
 }


### PR DESCRIPTION
Added:
- chain info graph ql table
- contract now has an array relationship with the token holder
- transfer has an object relationship with the contract 

- contract address check cleaned

- Chain info subscription on pages: Block, contracts, tokens, extrinsic, events, transfers
- Contract page filtering
- Repaired transfer page, now it subscribes to transfer table rather then extrinsics
- Contract source has a nicer view
- Tokens page additional cells: Symbol, Holders
