### PR TITLE
Save space in transfers table

### DIFF
--- a/frontend/pages/transfers.vue
+++ b/frontend/pages/transfers.vue
@@ -34,10 +34,14 @@
                 ># {{ formatNumber(item.block_id) }}</Cell
               >
 
-              <Cell class="list-view__age">
+              <Cell
+                v-b-tooltip.hover
+                class="list-view__age"
+                :title="formatTimestamp(item.timestamp)"
+              >
                 <font-awesome-icon :icon="['far', 'clock']" />
                 <span>{{ getAge(item.timestamp) }}</span>
-                <span>({{ formatTimestamp(item.timestamp) }})</span>
+                <!-- <span>({{ formatTimestamp(item.timestamp) }})</span> -->
               </Cell>
 
               <Cell


### PR DESCRIPTION
Changed Age cell content in transfers table to save space - displayed timestamp is now visible only in tooltip when cell is hovered.