### PR TITLE
use same github pipeline job for unittest + lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit-test:
+  unit-test-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,13 +19,4 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn workspaces run test
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'yarn'
-      - run: yarn install
       - run: yarn workspaces run lint


### PR DESCRIPTION
This PR modifies github pipeline CI to use the same job for both unit testing and linting.  This is optimal as the same environment can be used.