### PR TITLE
Linking native token holders to accounts

### DIFF
--- a/crawler/src/crawler/block.ts
+++ b/crawler/src/crawler/block.ts
@@ -243,7 +243,6 @@ export default async (
     .filter(isExtrinsicNativeTransfer)
     .map(extrinsicBodyToTransfer));
 
-
   // EVM Logs
   logger.info('Retrieving EVM log if contract is ERC20 token');
   const evmLogs = await extrinsicToEvmLogs(extrinsics);
@@ -258,7 +257,7 @@ export default async (
 
   // Evm Token Holders
   logger.info('Extracting EVM token holders');
-  let tokenHolders = await processEvmTokenHolders(evmLogs);
+  const tokenHolders = await processEvmTokenHolders(evmLogs);
   transactions += tokenHolders.length;
 
   // Accounts

--- a/crawler/src/crawler/block.ts
+++ b/crawler/src/crawler/block.ts
@@ -243,9 +243,6 @@ export default async (
     .filter(isExtrinsicNativeTransfer)
     .map(extrinsicBodyToTransfer));
 
-  // Native token holders
-  logger.info('Extracting native token holders from transfers');
-  const tokenHolders = await processNativeTokenHolders(transfers);
 
   // EVM Logs
   logger.info('Retrieving EVM log if contract is ERC20 token');
@@ -261,39 +258,39 @@ export default async (
 
   // Evm Token Holders
   logger.info('Extracting EVM token holders');
-  let evmTokenHolders = await processEvmTokenHolders(evmLogs);
-  transactions += evmTokenHolders.length;
-  tokenHolders.push(...evmTokenHolders);
-  evmTokenHolders = [];
+  let tokenHolders = await processEvmTokenHolders(evmLogs);
+  transactions += tokenHolders.length;
 
   // Accounts
   logger.info('Compressing transfer, event accounts, evm claim account');
-  const allAccounts: AccountHead[][] = [];
-  allAccounts.push(...transfers.map(extractTransferAccounts));
-  allAccounts.push(...events.map(accountNewOrKilled));
+  const allAccounts: AccountHead[] = [];
+  allAccounts.push(...transfers.flatMap(extractTransferAccounts));
+  allAccounts.push(...events.flatMap(accountNewOrKilled));
   allAccounts.push(
     ...extrinsics
       .filter(isExtrinsicEvmClaimAccount)
-      .map(extrinsicToEvmClaimAccount),
+      .flatMap(extrinsicToEvmClaimAccount),
   );
 
   logger.info('Extracting, compressing and dropping duplicate accounts');
-  let insertOrDeleteAccount = dropDuplicates(
-    allAccounts.flat(),
-    'address',
-  ).filter(({ address }) => address.length === 48);
+  let insertOrDeleteAccount = dropDuplicates(allAccounts, 'address')
+    .filter(({ address }) => address.length === 48);
 
   logger.info('Retrieving used account info');
   transactions += insertOrDeleteAccount.length;
   let accounts = await resolvePromisesAsChunks(
     insertOrDeleteAccount.map(accountHeadToBody),
   );
+  insertOrDeleteAccount = [];
+
+  // Native token holders
+  logger.info('Extracting native token holders from accounts');
+  tokenHolders.push(...processNativeTokenHolders(accounts));
 
   logger.info('Inserting or updating accounts');
   await insertAccounts(accounts);
   // Free memory
   accounts = [];
-  insertOrDeleteAccount = [];
 
   // Staking Slash
   logger.info('Inserting staking slashes');

--- a/crawler/src/crawler/tokenHolder.ts
+++ b/crawler/src/crawler/tokenHolder.ts
@@ -1,38 +1,13 @@
-import { nodeProvider } from '../utils/connector';
 import {
-  REEF_CONTRACT_ADDRESS, resolvePromisesAsChunks, REEF_DEFAULT_DATA, dropDuplicatesMultiKey,
+  REEF_CONTRACT_ADDRESS, resolvePromisesAsChunks, REEF_DEFAULT_DATA, dropDuplicatesMultiKey, dropDuplicates,
 } from '../utils/utils';
 import {
   isErc20TransferEvent, isErc721TransferEvent, isErc1155TransferSingleEvent, isErc1155TransferBatchEvent,
 } from './evmEvent';
 import {
-  Transfer, NativeTokenHolderHead, TokenHolder, EvmLogWithDecodedEvent, TokenHolderHead, TokenType,
+  TokenHolder, EvmLogWithDecodedEvent, TokenHolderHead, TokenType, AccountBody,
 } from './types';
 import { balanceOf, balanceOfErc1155, findNativeAddress } from './utils';
-
-const extractNativeTokenHolderFromTransfer = ({
-  fromAddress, toAddress, timestamp,
-}: Transfer): NativeTokenHolderHead[] => [
-  {
-    timestamp, signerAddress: fromAddress, info: { ...REEF_DEFAULT_DATA }, tokenAddress: REEF_CONTRACT_ADDRESS,
-  },
-  {
-    timestamp, signerAddress: toAddress, info: { ...REEF_DEFAULT_DATA }, tokenAddress: REEF_CONTRACT_ADDRESS,
-  },
-];
-
-const nativeTokenHolder = async (tokenHolderHead: NativeTokenHolderHead): Promise<TokenHolder> => {
-  const signer = tokenHolderHead.signerAddress;
-  const balance = await nodeProvider.query((provider) => provider.api.derive.balances.all(signer));
-
-  return {
-    ...tokenHolderHead,
-    type: 'Account',
-    evmAddress: '',
-    nftId: null,
-    balance: balance.freeBalance.toString(),
-  };
-};
 
 const prepareTokenHolderHead = (evmAddress: string, nftId: null | string, type: TokenType, {
   timestamp, address: tokenAddress, contractData, abis, name,
@@ -99,15 +74,16 @@ export const processEvmTokenHolders = async (evmLogs: EvmLogWithDecodedEvent[]):
   return resolvePromisesAsChunks(tokenHolders);
 };
 
-export const processNativeTokenHolders = async (transfers: Transfer[]): Promise<TokenHolder[]> => {
-  const tokenHolders = dropDuplicatesMultiKey(
-    transfers.flatMap(extractNativeTokenHolderFromTransfer),
-    ['signerAddress', 'tokenAddress'],
-  );
-
-  return resolvePromisesAsChunks(
-    tokenHolders
-      .filter(({ signerAddress }) => signerAddress !== 'deleted')
-      .map(nativeTokenHolder),
-  );
-};
+export const processNativeTokenHolders = (accounts: AccountBody[]): TokenHolder[] => 
+  dropDuplicates(accounts, "address")
+    .filter(({address}) => address != 'deleted')
+    .map(({address, timestamp, freeBalance}): TokenHolder => ({
+      timestamp,
+      signerAddress: address,
+      tokenAddress: REEF_CONTRACT_ADDRESS,
+      info: { ...REEF_DEFAULT_DATA },
+      balance: freeBalance,
+      type: 'Account',
+      evmAddress: '',
+      nftId: null,
+    }));

--- a/crawler/src/crawler/tokenHolder.ts
+++ b/crawler/src/crawler/tokenHolder.ts
@@ -74,15 +74,14 @@ export const processEvmTokenHolders = async (evmLogs: EvmLogWithDecodedEvent[]):
   return resolvePromisesAsChunks(tokenHolders);
 };
 
-export const processNativeTokenHolders = (accounts: AccountBody[]): TokenHolder[] => 
-  dropDuplicates(accounts, "address")
-    .map(({address, timestamp, freeBalance}): TokenHolder => ({
-      timestamp,
-      signerAddress: address,
-      tokenAddress: REEF_CONTRACT_ADDRESS,
-      info: { ...REEF_DEFAULT_DATA },
-      balance: freeBalance,
-      type: 'Account',
-      evmAddress: '',
-      nftId: null,
-    }));
+export const processNativeTokenHolders = (accounts: AccountBody[]): TokenHolder[] => dropDuplicates(accounts, 'address')
+  .map(({ address, timestamp, freeBalance }): TokenHolder => ({
+    timestamp,
+    signerAddress: address,
+    tokenAddress: REEF_CONTRACT_ADDRESS,
+    info: { ...REEF_DEFAULT_DATA },
+    balance: freeBalance,
+    type: 'Account',
+    evmAddress: '',
+    nftId: null,
+  }));

--- a/crawler/src/crawler/tokenHolder.ts
+++ b/crawler/src/crawler/tokenHolder.ts
@@ -76,7 +76,6 @@ export const processEvmTokenHolders = async (evmLogs: EvmLogWithDecodedEvent[]):
 
 export const processNativeTokenHolders = (accounts: AccountBody[]): TokenHolder[] => 
   dropDuplicates(accounts, "address")
-    .filter(({address}) => address != 'deleted')
     .map(({address, timestamp, freeBalance}): TokenHolder => ({
       timestamp,
       signerAddress: address,

--- a/db/hasura/metadata/databases/reefexplorer/tables/public_evm_event.yaml
+++ b/db/hasura/metadata/databases/reefexplorer/tables/public_evm_event.yaml
@@ -5,6 +5,9 @@ object_relationships:
 - name: event
   using:
     foreign_key_constraint_on: event_id
+- name: contract
+  using:
+    foreign_key_constraint_on: contract_address
 select_permissions:
 - permission:
     allow_aggregations: true

--- a/db/hasura/metadata/databases/reefexplorer/tables/public_evm_event.yaml
+++ b/db/hasura/metadata/databases/reefexplorer/tables/public_evm_event.yaml
@@ -7,7 +7,13 @@ object_relationships:
     foreign_key_constraint_on: event_id
 - name: contract
   using:
-    foreign_key_constraint_on: contract_address
+    manual_configuration:
+      remote_table:
+        schema: public
+        name: contract
+      column_mapping:
+        contract_address: address
+
 select_permissions:
 - permission:
     allow_aggregations: true


### PR DESCRIPTION
moving native token holders from transfer events to accounts. Now not only native transfer events updated token holder table but can also detect paid transactions (solidity function setters, claim account, ...)