### PR TITLE
Add timeout to closeProviders method

### DIFF
--- a/crawler/src/crawler.ts
+++ b/crawler/src/crawler.ts
@@ -4,7 +4,7 @@ import config from './config';
 import processBlocks, { processInitialBlocks } from './crawler/block';
 import { deleteUnfinishedBlocks, lastBlockInDatabase } from './queries/block';
 import { nodeProvider } from './utils/connector';
-import { min, wait } from './utils/utils';
+import { min, wait, promiseWithTimeout } from './utils/utils';
 import logger from './utils/logger';
 import parseAndInsertContracts from './crawler/contracts';
 // Importing @sentry/tracing patches the global hub for tracing to work.
@@ -92,9 +92,15 @@ Promise.resolve()
   .catch(async (error) => {
     logger.error(error);
     Sentry.captureException(error);
-    await nodeProvider.closeProviders();
+
+    try {
+      await promiseWithTimeout(nodeProvider.closeProviders(), 200, Error('Failed to close proivders!'));
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+
     logger.error('Finished');
-    Sentry.close(2000).then(function() {
+    Sentry.close(2000).then(() => {
       process.exit(-1);
-    })
+    });
   });

--- a/crawler/src/utils/utils.ts
+++ b/crawler/src/utils/utils.ts
@@ -101,3 +101,19 @@ export const resolvePromisesAsChunks = async <T>(
 export const removeUndefinedItem = <Type, >(item: (Type|undefined)): item is Type => item !== undefined;
 
 export const toChecksumAddress = (address: string): string => utils.getAddress(address.trim().toLowerCase());
+
+export const promiseWithTimeout = <T>(
+  promise: Promise<T>,
+  ms: number,
+  timeoutError = new Error('Promise timed out'),
+): Promise<T> => {
+  // create a promise that rejects in milliseconds
+  const timeout = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      reject(timeoutError);
+    }, ms);
+  });
+
+  // returns a race between timeout and the passed promise
+  return Promise.race<T>([promise, timeout]);
+};


### PR DESCRIPTION
This PR introduces a timeout on the promise `.closeProivders()`.  Therefore if the promise takes too long to resolve then it will timoeut.