### PR TITLE
Transfer amount, fronetend transfer addresses & staking rewards 

### DIFF
--- a/crawler/src/crawler/extrinsic.ts
+++ b/crawler/src/crawler/extrinsic.ts
@@ -63,11 +63,9 @@ export const extrinsicBodyToTransfer = async ({
     ? (await nodeProvider.query((provider) => provider.api.query.evmAccounts.evmAddresses(fromAddress))).toString()
     : 'null';
 
-  const denom: string = extrinsic.method.section === 'currencies' ? args[1].token : 'REEF';
-  const amount: string = BigNumber.from(
-    extrinsic.method.section === 'currencies' ? args[2] : args[1],
-  ).toString();
+  const amount = BigNumber.from(args[args.length-1]).toString();
   const feeAmount = BigNumber.from(signedData!.fee.partialFee).toString();
+  const denom = extrinsic.method.section === 'currencies' ? args[1].token : 'REEF';
 
   return {
     denom,

--- a/frontend/components/AccountTransfers.vue
+++ b/frontend/components/AccountTransfers.vue
@@ -238,16 +238,14 @@ export default {
           return !this.accountId
         },
         result({ data }) {
-          this.transfers = data.transfer.map(
-            (t) => ({
-              ...t,
-              extrinsic_hash: t.extrinsic.hash,
-              to_address: t.to_address || t.to_evm_address,
-              from_address: t.from_address || t.from_evm_address,
-              symbol: t.token.verified_contract?.contract_data?.symbol,
-              decimals: t.token.verified_contract?.contract_data?.decimals,
-            })
-          )
+          this.transfers = data.transfer.map((t) => ({
+            ...t,
+            extrinsic_hash: t.extrinsic.hash,
+            to_address: t.to_address || t.to_evm_address,
+            from_address: t.from_address || t.from_evm_address,
+            symbol: t.token.verified_contract?.contract_data?.symbol,
+            decimals: t.token.verified_contract?.contract_data?.decimals,
+          }))
           this.totalRows = this.transfers.length
           this.loading = false
         },

--- a/frontend/components/AccountTransfers.vue
+++ b/frontend/components/AccountTransfers.vue
@@ -71,7 +71,7 @@
               :size="20"
             />
             <span>
-              {{ shortAddress(item.from_address || item.from_evm_address) }}
+              {{ shortAddress(item.from_address) }}
             </span>
           </Cell>
 
@@ -85,7 +85,7 @@
               :size="20"
             />
             <span>
-              {{ shortAddress(item.to_address || item.to_evm_address) }}
+              {{ shortAddress(item.to_address) }}
             </span>
           </Cell>
 
@@ -239,10 +239,11 @@ export default {
         },
         result({ data }) {
           this.transfers = data.transfer.map(
-            // (t) => (t.extrinsic_hash = t.extrinsic.hash) && t
             (t) => ({
               ...t,
               extrinsic_hash: t.extrinsic.hash,
+              to_address: t.to_address || t.to_evm_address,
+              from_address: t.from_address || t.from_evm_address,
               symbol: t.token.verified_contract?.contract_data?.symbol,
               decimals: t.token.verified_contract?.contract_data?.decimals,
             })

--- a/frontend/components/StakingRewards.vue
+++ b/frontend/components/StakingRewards.vue
@@ -165,7 +165,6 @@ export default {
         result({ data }) {
           this.stakingRewards = data.staking.map((stakeEv) => {
             const timestamp = new Date(stakeEv.timestamp).getTime() / 1000
-            console.log(stakeEv.event.extrinsic.signed_data)
             return {
               timestamp,
               timeago: timestamp,
@@ -173,7 +172,7 @@ export default {
               address: stakeEv.signer,
               block_id: stakeEv.event.block_id,
               hash: stakeEv.event.extrinsic.hash,
-              fee: stakeEv.event.extrinsic.signed_data.fee.partialFee,
+              fee: stakeEv.event.extrinsic.signed_data?.fee.partialFee || 0,
               extrinsicIndex: stakeEv.event.extrinsic.index,
             }
           })

--- a/frontend/pages/verifyContract.vue
+++ b/frontend/pages/verifyContract.vue
@@ -330,6 +330,10 @@ export default {
       ],
       compilerVersions: [
         { text: 'Please select', value: null },
+        { text: 'v0.8.10+commit.fc410830', value: 'v0.8.10+commit.fc410830' },
+        { text: 'v0.8.9+commit.e5eed63a', value: 'v0.8.9+commit.e5eed63a' },
+        { text: 'v0.8.8+commit.dddeac2f', value: 'v0.8.8+commit.dddeac2f' },
+        { text: 'v0.8.7+commit.e28d00a7', value: 'v0.8.7+commit.e28d00a7' },
         { text: 'v0.8.6+commit.11564f7e', value: 'v0.8.6+commit.11564f7e' },
         { text: 'v0.8.5+commit.a4f2e591', value: 'v0.8.5+commit.a4f2e591' },
         { text: 'v0.8.4+commit.c7e474f2', value: 'v0.8.4+commit.c7e474f2' },


### PR DESCRIPTION
- Reading transfer amount as the last extrinsic argument. (To verify this you can query extrinsics where the section is 'balances' or 'currencies')
- Frontend account transfer - correcting and using only to/from address and repairing them when data is fetched
- Frontend staking rewards - it is possible that extrinsic does not have signed data. In that case display 0.