### PR TITLE
Safari account balance css fix

### DIFF
--- a/frontend/pages/account/_id.vue
+++ b/frontend/pages/account/_id.vue
@@ -335,7 +335,7 @@ export default {
       //noinspection CssInvalidPropertyValue
       background-clip: text;
       -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
+      //-webkit-text-fill-color: transparent;
     }
   }
 


### PR DESCRIPTION
<img width="405" alt="image" src="https://user-images.githubusercontent.com/10501247/162138072-91357dfa-de2e-4ca5-bc17-a19a1eaa91f1.png">

The data was properly binded to the DOM, but its not showing on safari - both Mac/IOS